### PR TITLE
HAProxy have joined the Netdev Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Current members / sponsors of the netdev foundation are (in alphabetical order):
  - Alibaba
  - Fastly
  - Google
+ - HAProxy
  - Jump Trading
  - Meta
  - Red Hat


### PR DESCRIPTION
A big welcome to HAProxy who have joined the Netdev Foundation.