### PR TITLE
HAProxy Technologies have joined the Netdev Foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Current members / sponsors of the netdev foundation are (in alphabetical order):
  - Alibaba
  - Fastly
  - Google
- - HAProxy
+ - HAProxy Technologies
  - Jump Trading
  - Meta
  - Red Hat


### PR DESCRIPTION
This corrects the entry for HAProxy Technologies
in the list of members.